### PR TITLE
Fixing generation of download url

### DIFF
--- a/unsplash_download/unsplash_download.py
+++ b/unsplash_download/unsplash_download.py
@@ -15,7 +15,7 @@ Options:
 """
 
 DEBUG = False
-ud_version='1.0.2'
+ud_version='1.0.3'
 
 import urllib.request
 import re
@@ -49,8 +49,13 @@ while True:
     try:
         soup = BeautifulSoup(urllib.request.urlopen(url).read(), "lxml")
         for tag in soup.find_all(href=link_search):
-            image_id     = str(tag['href']).split('/')[2]
-            download_url = base_url + str(tag['href'])
+            if arguments['<profile>']:
+              image_id     = str(tag['href']).split('/')[2]
+              download_url = base_url + str(tag['href'])
+            else:
+              image_id     = str(tag['href']).split('/')[4]
+              download_url = str(tag['href'])
+
 
             if os.path.exists("%s/%s.jpeg" % (download_path, image_id)):
                 print("Not downloading duplicate %s" % download_url)
@@ -58,7 +63,7 @@ while True:
 
             print("Downloading %s" % download_url)
             urllib.request.urlretrieve(
-                base_url + str(tag["href"]),
+                download_url,
                 "%s/%s.jpeg" % (download_path, image_id)
             )
 


### PR DESCRIPTION
I feel really bad, I broke your project with my last commit!

I fixed the issue with it rendering the download URL incorrectly.

Downloading form a users page
```
$ python3 unsplash_download.py ~/Dropbox/Photos/wallpaper @chuchad
Parsing page https://unsplash.com/@chuchad/?page=1
Not downloading duplicate https://unsplash.com/photos/BJQABP4rU9M/download
Not downloading duplicate https://unsplash.com/photos/BJQABP4rU9M/download
Downloading https://unsplash.com/photos/LztzSbEdO7A/download
```

Running it against the main page
```bash
$ python3 unsplash_download.py ~/Dropbox/Photos/wallpaper
Parsing page https://unsplash.com/?page=1
Downloading http://unsplash.com/photos/6wQId4r0uA4/download
Downloading http://unsplash.com/photos/aIYFR0vbADk/download
Downloading http://unsplash.com/photos/DMcI0cmYJYk/download
Downloading http://unsplash.com/photos/90FzfXFEEjo/download
Not downloading duplicate http://unsplash.com/photos/5eZu5p0vSPg/download
Not downloading duplicate http://unsplash.com/photos/u1iFdXU1tl0/download
Not downloading duplicate http://unsplash.com/photos/jq3BQshrzVQ/download
```