### PR TITLE
Looks like they changed their URLs around again. Fixing

### DIFF
--- a/unsplash_download/unsplash_download.py
+++ b/unsplash_download/unsplash_download.py
@@ -49,13 +49,8 @@ while True:
     try:
         soup = BeautifulSoup(urllib.request.urlopen(url).read(), "lxml")
         for tag in soup.find_all(href=link_search):
-            if arguments['<profile>']:
-              image_id     = str(tag['href']).split('/')[2]
-              download_url = base_url + str(tag['href'])
-            else:
-              image_id     = str(tag['href']).split('/')[4]
-              download_url = str(tag['href'])
-
+            download_url = str(tag['href'])
+            image_id     = download_url.split('/')[4]
 
             if os.path.exists("%s/%s.jpeg" % (download_path, image_id)):
                 print("Not downloading duplicate %s" % download_url)


### PR DESCRIPTION
After my last PR, unsplash changed up their URLs. I ran it with some print statements and it looks like `image_id` is `str(tag['href']).split('/')[4]` for both the main page and an individual profile
```
$ python3 unsplash_download.py ~/Dropbox/Photos/wallpaper
Parsing page https://unsplash.com/?page=1
image_id is sYegwYtIqJg
download_url is http://unsplash.com/photos/sYegwYtIqJg/download
```

and then running it against a profile

```
python3 unsplash_download.py ~/Dropbox/Photos/wallpaper @joerobot
Parsing page https://unsplash.com/@joerobot/?page=1
image_id is vLICFzBqoYY
download_url is http://unsplash.com/photos/vLICFzBqoYY/download
image_id is _YOipESU2SE
```

I could submit another PR with the change if you'd like.